### PR TITLE
Add fixes for Ubuntu build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ gem install wpscan
 
 On MacOSX, if a ```Gem::FilePermissionError``` is raised due to the Apple's System Integrity Protection (SIP), either install RVM and install wpscan again, or run ```sudo gem install -n /usr/local/bin wpscan``` (see [#1286](https://github.com/wpscanteam/wpscan/issues/1286))
 
+On Ubuntu, the following packages may be needed: ```sudo apt-get install ruby-dev``` ```sudo apt-get install libxml2-dev``` ```sudo apt-get install zlib1g-dev``` to satisfy nokogiri dependencies.
+
 ### From sources (NOT Recommended)
 
 Prerequisites: Git


### PR DESCRIPTION
A "gem install wpscan" will produce multiple errors on Ubuntu 18.04, the following packages may be needed to satisfy nokogiri dependencies: ruby-dev, libxml2-dev, zlib1g-dev.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.